### PR TITLE
Hardening: configurable HTTP timeout + explicit storage fallback visibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ FAILED_DELIVERY_TTL=604800   # Keep failed deliveries for 7 days
 TELEGRAM_RETRIES=2           # Number of retries for Telegram API calls (default: 2)
 MESSAGE_VERBOSITY=compact    # compact | detailed (default: compact)
 
+# Outbound HTTP timeout (seconds, 1.0-60.0)
+HTTP_TIMEOUT_SECONDS=10
+
 # Circuit breaker configuration
 CIRCUIT_BREAKER_THRESHOLD=5  # Failures before opening circuit (default: 5)
 CIRCUIT_BREAKER_TIMEOUT=60   # Seconds before half-open (default: 60)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ Then follow the full setup guide: [`docs/deploy-vercel.md`](docs/deploy-vercel.m
 
 ---
 
+## Reliability Guarantees
+
+- **Bounded outbound HTTP timeout:** all outbound HTTP calls use `HTTP_TIMEOUT_SECONDS` (default `10`, validated range `1.0..60.0`). This applies to the shared app client and destination webhook clients.
+- **Storage backend behavior:**
+  - `STORAGE_BACKEND=memory`: in-process volatile state (best for local/dev).
+  - `STORAGE_BACKEND=redis`: Redis is primary. If Redis is unavailable at startup or runtime, the service falls back to memory and emits explicit warning/error logs (no silent fallback).
+- **Operational visibility:** `/health/deep` includes storage backend status (`configured_backend`, `effective_backend`, `fallback_active`, `fallback_reason`) so operators can detect degraded persistence quickly.
+- **Expectation in production:** use Redis-backed storage/rate limiting for durable idempotency and replay metadata across restarts/replicas. Memory fallback is best-effort continuity, not durable persistence.
+
+---
+
 ## Quick Start
 
 ### 1) Clone and enter project
@@ -169,7 +180,7 @@ make down         # stop services
 | `/webhook/github` | POST | GitHub HMAC signature | Receive GitHub webhook events |
 | `/webhook/generic` | POST | `X-Webhook-Token` | Receive generic webhook payloads |
 | `/health` | GET | None | Basic liveness check |
-| `/health/deep` | GET | None | Downstream-aware health (Telegram + breaker state) |
+| `/health/deep` | GET | None | Downstream-aware health (Telegram + breaker + storage backend state) |
 | `/metrics` | GET | None | Prometheus metrics export |
 | `/deliveries` | GET | Admin API key (`read+`) | List failed deliveries |
 | `/deliveries/{id}/replay` | POST | Admin API key (`replay+`) | Replay one failed delivery |

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,4 +1,4 @@
-from pydantic import field_validator
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -28,6 +28,9 @@ class Settings(BaseSettings):
     storage_backend: str = "memory"  # memory | redis
     redis_url: str = "redis://redis:6379/0"
     redis_key_prefix: str = "webhook_bridge"
+
+    # Outbound HTTP behavior
+    http_timeout_seconds: float = Field(default=10.0, ge=1.0, le=60.0)
 
     # Circuit breaker settings
     circuit_breaker_threshold: int = 5  # Failures before opening

--- a/app/infra/storage.py
+++ b/app/infra/storage.py
@@ -11,6 +11,7 @@ import logging
 import time
 import uuid
 from collections.abc import Mapping
+from datetime import datetime, timezone
 from typing import Any, Protocol
 
 try:
@@ -431,19 +432,40 @@ class FallbackStorage:
     def __init__(self, primary: Storage, fallback: Storage) -> None:
         self._primary = primary
         self._fallback = fallback
-        self._warned = False
+        self._fallback_active = False
+        self._fallback_reason: str | None = None
+        self._fallback_since: str | None = None
+
+    def _activate_fallback(self, operation: str, exc: Exception) -> None:
+        if not self._fallback_active:
+            self._fallback_active = True
+            self._fallback_reason = str(exc)
+            self._fallback_since = datetime.now(timezone.utc).isoformat()
+            logger.error(
+                "Primary Redis storage unavailable, enabling memory fallback operation=%s error=%s",
+                operation,
+                exc,
+            )
+            return
+        logger.warning(
+            "Using memory fallback for storage operation=%s error=%s",
+            operation,
+            exc,
+        )
+
+    def fallback_state(self) -> dict[str, str | bool | None]:
+        return {
+            "active": self._fallback_active,
+            "reason": self._fallback_reason,
+            "since": self._fallback_since,
+        }
 
     async def is_duplicate_delivery(self, delivery_id: str | None) -> bool:
         """Check idempotency using primary storage, then fallback if needed."""
         try:
             return await self._primary.is_duplicate_delivery(delivery_id)
         except RedisError as exc:
-            if not self._warned:
-                logger.warning(
-                    "Primary Redis storage unavailable, falling back to memory: %s",
-                    exc,
-                )
-                self._warned = True
+            self._activate_fallback("is_duplicate_delivery", exc)
             return await self._fallback.is_duplicate_delivery(delivery_id)
 
     async def is_duplicate_replay_operation(self, operation_key: str, ttl_seconds: int) -> bool:
@@ -451,12 +473,7 @@ class FallbackStorage:
         try:
             return await self._primary.is_duplicate_replay_operation(operation_key, ttl_seconds)
         except RedisError as exc:
-            if not self._warned:
-                logger.warning(
-                    "Primary Redis storage unavailable, falling back to memory: %s",
-                    exc,
-                )
-                self._warned = True
+            self._activate_fallback("is_duplicate_replay_operation", exc)
             return await self._fallback.is_duplicate_replay_operation(operation_key, ttl_seconds)
 
     async def store_failed_delivery(
@@ -479,12 +496,7 @@ class FallbackStorage:
                 delivery_id=delivery_id,
             )
         except RedisError as exc:
-            if not self._warned:
-                logger.warning(
-                    "Primary Redis storage unavailable, falling back to memory: %s",
-                    exc,
-                )
-                self._warned = True
+            self._activate_fallback("store_failed_delivery", exc)
             return await self._fallback.store_failed_delivery(
                 source=source,
                 event_type=event_type,
@@ -504,28 +516,32 @@ class FallbackStorage:
         """List failed deliveries with fallback behavior."""
         try:
             return await self._primary.list_failed_deliveries(source, status, limit, offset)
-        except RedisError:
+        except RedisError as exc:
+            self._activate_fallback("list_failed_deliveries", exc)
             return await self._fallback.list_failed_deliveries(source, status, limit, offset)
 
     async def get_failed_delivery(self, failed_id: str) -> dict[str, Any] | None:
         """Get failed delivery by ID with fallback behavior."""
         try:
             return await self._primary.get_failed_delivery(failed_id)
-        except RedisError:
+        except RedisError as exc:
+            self._activate_fallback("get_failed_delivery", exc)
             return await self._fallback.get_failed_delivery(failed_id)
 
     async def update_failed_delivery_status(self, failed_id: str, status: str) -> None:
         """Update failed delivery status with fallback behavior."""
         try:
             await self._primary.update_failed_delivery_status(failed_id, status)
-        except RedisError:
+        except RedisError as exc:
+            self._activate_fallback("update_failed_delivery_status", exc)
             await self._fallback.update_failed_delivery_status(failed_id, status)
 
     async def update_failed_delivery(self, failed_id: str, updates: Mapping[str, Any]) -> None:
         """Apply partial updates with fallback behavior."""
         try:
             await self._primary.update_failed_delivery(failed_id, updates)
-        except RedisError:
+        except RedisError as exc:
+            self._activate_fallback("update_failed_delivery", exc)
             await self._fallback.update_failed_delivery(failed_id, updates)
 
     async def upsert_delivery_ledger(
@@ -538,13 +554,15 @@ class FallbackStorage:
     ) -> dict[str, Any]:
         try:
             return await self._primary.upsert_delivery_ledger(provider, inbound_delivery_id, payload_hash, status, reason)
-        except RedisError:
+        except RedisError as exc:
+            self._activate_fallback("upsert_delivery_ledger", exc)
             return await self._fallback.upsert_delivery_ledger(provider, inbound_delivery_id, payload_hash, status, reason)
 
     async def get_delivery_ledger(self, provider: str, inbound_delivery_id: str) -> dict[str, Any] | None:
         try:
             return await self._primary.get_delivery_ledger(provider, inbound_delivery_id)
-        except RedisError:
+        except RedisError as exc:
+            self._activate_fallback("get_delivery_ledger", exc)
             return await self._fallback.get_delivery_ledger(provider, inbound_delivery_id)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from app.api.replay import router as replay_router
 from app.services.routing import load_routes, route_event
 from app.api.sandbox import router as sandbox_router
 from app.core.security import describe_admin_auth_mode, verify_generic_token, verify_github_signature
-from app.infra.storage import Redis, RedisError, Storage, create_storage_backend
+from app.infra.storage import FallbackStorage, Redis, RedisError, Storage, create_storage_backend
 from app.services.reliability import payload_hash
 from app.services.tg_client import TelegramSendError, format_generic, send_message
 from app.api.websocket import broadcaster, router as ws_router
@@ -128,7 +128,7 @@ def _with_request_id_footer(message: str, request_id: str) -> str:
 
 def _initialize_app_state(app: FastAPI) -> None:
     if not hasattr(app.state, "http"):
-        app.state.http = httpx.AsyncClient(timeout=10)
+        app.state.http = httpx.AsyncClient(timeout=settings.http_timeout_seconds)
 
     if not hasattr(app.state, "redis"):
         app.state.redis = None
@@ -146,6 +146,38 @@ def _initialize_app_state(app: FastAPI) -> None:
     if not hasattr(app.state, "routes"):
         app.state.routes = load_routes()
 
+
+
+
+def _storage_health(app: FastAPI) -> dict[str, object]:
+    configured = settings.storage_backend.lower()
+    storage = getattr(app.state, "storage", None)
+    redis_client = getattr(app.state, "redis", None)
+
+    fallback_active = False
+    fallback_reason: str | None = None
+    effective_backend = configured
+
+    if configured == "redis" and redis_client is None:
+        fallback_active = True
+        fallback_reason = "redis_client_unavailable_at_startup"
+        effective_backend = "memory"
+
+    if isinstance(storage, FallbackStorage):
+        snapshot = storage.fallback_state()
+        if snapshot.get("active"):
+            fallback_active = True
+            fallback_reason = str(snapshot.get("reason") or "runtime_redis_error")
+            effective_backend = "memory_fallback"
+        elif configured == "redis":
+            effective_backend = "redis"
+
+    return {
+        "configured_backend": configured,
+        "effective_backend": effective_backend,
+        "fallback_active": fallback_active,
+        "fallback_reason": fallback_reason,
+    }
 
 def _get_storage(request: Request) -> Storage:
     _initialize_app_state(request.app)
@@ -255,6 +287,7 @@ def create_app() -> FastAPI:
                     "circuit_breaker": {
                         "state": telegram_circuit.state.value,
                     },
+                    "storage": _storage_health(app),
                 },
             )
         except TelegramError as exc:
@@ -267,6 +300,7 @@ def create_app() -> FastAPI:
                     "circuit_breaker": {
                         "state": telegram_circuit.state.value,
                     },
+                    "storage": _storage_health(app),
                 },
             )
 

--- a/destinations/discord.py
+++ b/destinations/discord.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 
+from app.core.config import settings
 from destinations.base import Destination, DestinationError
 
 logger = logging.getLogger(__name__)
@@ -72,7 +73,7 @@ class DiscordDestination(Destination):
                 resp = await self._http_client.post(self._webhook_url, json=body)
                 resp.raise_for_status()
             else:
-                async with httpx.AsyncClient(timeout=10) as client:
+                async with httpx.AsyncClient(timeout=settings.http_timeout_seconds) as client:
                     resp = await client.post(self._webhook_url, json=body)
                     resp.raise_for_status()
         except httpx.HTTPStatusError as exc:

--- a/destinations/slack.py
+++ b/destinations/slack.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 
+from app.core.config import settings
 from destinations.base import Destination, DestinationError
 
 logger = logging.getLogger(__name__)
@@ -76,7 +77,7 @@ class SlackDestination(Destination):
                 resp = await self._http_client.post(self._webhook_url, json=body)
                 resp.raise_for_status()
             else:
-                async with httpx.AsyncClient(timeout=10) as client:
+                async with httpx.AsyncClient(timeout=settings.http_timeout_seconds) as client:
                     resp = await client.post(self._webhook_url, json=body)
                     resp.raise_for_status()
         except httpx.HTTPStatusError as exc:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -62,6 +62,9 @@ def test_health_deep_success(monkeypatch) -> None:
     assert data["status"] == "ok"
     assert data["telegram"]["connected"] is True
     assert data["telegram"]["bot_username"] == "test_bot"
+    assert data["storage"]["configured_backend"] == "memory"
+    assert data["storage"]["effective_backend"] == "memory"
+    assert data["storage"]["fallback_active"] is False
 
 
 def test_health_deep_failure(monkeypatch) -> None:
@@ -82,6 +85,7 @@ def test_health_deep_failure(monkeypatch) -> None:
     data = response.json()
     assert data["status"] == "degraded"
     assert data["telegram"]["connected"] is False
+    assert "storage" in data
 
 
 def test_github_ping(monkeypatch) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -94,6 +94,7 @@ def test_fallback_storage_uses_memory_when_primary_fails() -> None:
     memory = MemoryStorage(idempotency_ttl=3600)
     storage = FallbackStorage(primary=_FailingStorage(), fallback=memory)
 
+    assert storage.fallback_state()["active"] is False
     assert asyncio.run(storage.is_duplicate_delivery("dup-1")) is False
     assert asyncio.run(storage.is_duplicate_delivery("dup-1")) is True
 
@@ -105,3 +106,7 @@ def test_fallback_storage_uses_memory_when_primary_fails() -> None:
         )
     )
     assert failed_id in memory.failed_deliveries
+    state = storage.fallback_state()
+    assert state["active"] is True
+    assert state["reason"] == "down"
+    assert state["since"] is not None


### PR DESCRIPTION
## Summary
This PR applies focused reliability hardening from maintainer feedback while preserving existing API contracts.

### 1) Tighten hard-coded timeout defaults
- Added `HTTP_TIMEOUT_SECONDS` config (`default=10.0`, validated range `1.0..60.0`).
- Replaced hard-coded `timeout=10` usages with `settings.http_timeout_seconds` in:
  - shared app HTTP client (`app/main.py`)
  - Discord destination client
  - Slack destination client
- Added `HTTP_TIMEOUT_SECONDS=10` to `.env.example`.

### 2) Make storage fallback explicit/noisy
- Enhanced `FallbackStorage` to track runtime fallback state (`active`, `reason`, `since`).
- On first Redis failure, fallback activation logs at **error** level; subsequent fallback operations log warnings with operation context.
- Added `fallback_state()` accessor for operational visibility.

### 3) Surface fallback in health and docs
- `/health/deep` now includes a `storage` section with:
  - `configured_backend`
  - `effective_backend`
  - `fallback_active`
  - `fallback_reason`
- Added README section: **Reliability Guarantees** documenting timeout behavior, storage fallback semantics, and production expectations.

## Compatibility
- Existing endpoints and response contracts are preserved; `/health/deep` response is additive only.
- No behavior changes for deployments intentionally using memory backend.

## Risk notes
- If `STORAGE_BACKEND=redis` but Redis is unavailable, operators will now see explicit fallback logs and health/deep fallback indicators (intended).
- Timeout behavior remains default-equivalent (10s), now centrally configurable and validated.

## Validation
- Attempted targeted test run:
  - `.venv/bin/pytest -q tests/test_storage.py tests/test_main.py tests/test_destinations.py`
  - Blocked in this execution environment due Python runtime mismatch (system Python 3.9 vs project syntax using PEP 604 unions from 3.10+ during import).
- No `make test`/`make lint` targets exist in this repository Makefile.

## Migration / env changes
- New optional env var: `HTTP_TIMEOUT_SECONDS` (float, range `1.0..60.0`, default `10.0`).
- Recommended action for operators: set explicit value in production `.env` for predictable behavior.
