### PR TITLE
PR 2: Introduce destination registry foundation

### DIFF
--- a/destinations/__init__.py
+++ b/destinations/__init__.py
@@ -1,12 +1,44 @@
 """Multi-destination delivery package."""
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
 from destinations.base import Destination
 from destinations.discord import DiscordDestination
 from destinations.slack import SlackDestination
 from destinations.telegram import TelegramDestination
 
+DestinationFactory = Callable[..., Destination]
+T = TypeVar("T", bound=Destination)
+
+
+class DestinationRegistry:
+    """Simple destination factory registry."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, DestinationFactory] = {}
+
+    def register(self, name: str, factory: DestinationFactory) -> None:
+        key = name.strip().lower()
+        if not key:
+            raise ValueError("Destination name must be non-empty")
+        if key in self._factories:
+            raise ValueError(f"Destination {key!r} is already registered")
+        self._factories[key] = factory
+
+    def get(self, name: str) -> DestinationFactory | None:
+        key = name.strip().lower()
+        return self._factories.get(key)
+
+    def list_registered(self) -> list[str]:
+        return sorted(self._factories.keys())
+
+
 __all__ = [
     "Destination",
+    "DestinationRegistry",
     "DiscordDestination",
     "SlackDestination",
     "TelegramDestination",

--- a/tests/test_destination_registry.py
+++ b/tests/test_destination_registry.py
@@ -1,0 +1,67 @@
+"""Tests for destination registry foundation API."""
+
+import pytest
+
+from destinations import DestinationRegistry
+from destinations.base import Destination
+
+
+class DummyDestination(Destination):
+    @property
+    def name(self) -> str:
+        return "dummy"
+
+    async def send(self, message: str, *, event_type: str, payload: dict):
+        return None
+
+
+def dummy_factory(**kwargs) -> Destination:
+    return DummyDestination()
+
+
+def test_register_and_get_factory():
+    registry = DestinationRegistry()
+
+    registry.register("telegram", dummy_factory)
+
+    factory = registry.get("telegram")
+    assert factory is dummy_factory
+
+
+def test_get_missing_returns_none():
+    registry = DestinationRegistry()
+
+    assert registry.get("missing") is None
+
+
+def test_list_registered_sorted():
+    registry = DestinationRegistry()
+
+    registry.register("slack", dummy_factory)
+    registry.register("telegram", dummy_factory)
+
+    assert registry.list_registered() == ["slack", "telegram"]
+
+
+def test_duplicate_registration_rejected():
+    registry = DestinationRegistry()
+
+    registry.register("discord", dummy_factory)
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register("discord", dummy_factory)
+
+
+def test_registration_normalizes_name():
+    registry = DestinationRegistry()
+
+    registry.register("  TeLeGrAm  ", dummy_factory)
+
+    assert registry.get("telegram") is dummy_factory
+
+
+def test_register_requires_non_empty_name():
+    registry = DestinationRegistry()
+
+    with pytest.raises(ValueError, match="non-empty"):
+        registry.register("   ", dummy_factory)


### PR DESCRIPTION
## Summary
- introduce `DestinationRegistry` in `destinations/__init__.py`
- add registry API:
  - `register(name, factory)`
  - `get(name)`
  - `list_registered()`
- add duplicate registration protection with explicit `ValueError`
- keep `Destination` base contract unchanged

## Validation
- `TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=1 GITHUB_WEBHOOK_SECRET=x GENERIC_WEBHOOK_TOKEN=x ./.venv/bin/python -m pytest -q tests/test_destination_registry.py tests/test_destinations.py`
