### PR TITLE
PR 3: Migrate routing to destination registry

### DIFF
--- a/app/services/routing.py
+++ b/app/services/routing.py
@@ -32,6 +32,7 @@ import httpx
 import yaml
 
 from app.core.config import settings
+from destinations import DestinationRegistry
 from destinations.base import Destination, DestinationError
 from destinations.discord import DiscordDestination
 from destinations.slack import SlackDestination
@@ -94,24 +95,41 @@ def _extract_branch(event_type: str, payload: dict[str, Any]) -> str:
     return ""
 
 
-def _build_destination(name: str, http_client: httpx.AsyncClient | None = None) -> Destination | None:
-    """Instantiate a destination by name, using current settings."""
-    if name == "telegram":
-        return TelegramDestination()
-    if name == "discord":
+def bootstrap_builtin_destinations(registry: DestinationRegistry | None = None) -> DestinationRegistry:
+    """Register built-in destinations and return a ready registry."""
+    target = registry or DestinationRegistry()
+
+    target.register("telegram", lambda **kwargs: TelegramDestination())
+
+    def _discord_factory(**kwargs) -> Destination | None:
         url = settings.discord_webhook_url
         if not url:
             logger.warning("Route references 'discord' but DISCORD_WEBHOOK_URL is not set")
             return None
-        return DiscordDestination(url, http_client=http_client)
-    if name == "slack":
+        return DiscordDestination(url, http_client=kwargs.get("http_client"))
+
+    def _slack_factory(**kwargs) -> Destination | None:
         url = settings.slack_webhook_url
         if not url:
             logger.warning("Route references 'slack' but SLACK_WEBHOOK_URL is not set")
             return None
-        return SlackDestination(url, http_client=http_client)
-    logger.warning("Unknown destination %r in route config", name)
-    return None
+        return SlackDestination(url, http_client=kwargs.get("http_client"))
+
+    target.register("discord", _discord_factory)
+    target.register("slack", _slack_factory)
+    return target
+
+
+_DESTINATION_REGISTRY = bootstrap_builtin_destinations()
+
+
+def _build_destination(name: str, http_client: httpx.AsyncClient | None = None) -> Destination | None:
+    """Instantiate a destination by name via registry lookup."""
+    factory = _DESTINATION_REGISTRY.get(name)
+    if factory is None:
+        logger.warning("Unknown destination %r in route config", name)
+        return None
+    return factory(http_client=http_client)
 
 
 def load_routes(yaml_source: str | None = None) -> list[Route]:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -5,7 +5,16 @@ import tempfile
 
 import pytest
 
-from app.services.routing import RouteFilter, Route, load_routes, route_event, _extract_branch
+from app.services.routing import (
+    RouteFilter,
+    Route,
+    _DESTINATION_REGISTRY,
+    _extract_branch,
+    _build_destination,
+    bootstrap_builtin_destinations,
+    load_routes,
+    route_event,
+)
 from destinations.base import Destination, DestinationError
 
 
@@ -146,6 +155,30 @@ routes:
 # ---------------------------------------------------------------------------
 # route_event
 # ---------------------------------------------------------------------------
+
+class TestDestinationBootstrap:
+    def test_builtin_destinations_registered(self):
+        registry = bootstrap_builtin_destinations()
+
+        assert registry.get("telegram") is not None
+        assert registry.get("discord") is not None
+        assert registry.get("slack") is not None
+
+    def test_build_destination_uses_registry_lookup(self, monkeypatch):
+        calls = []
+
+        def factory(**kwargs):
+            calls.append(kwargs)
+            return FakeDestination("from-registry")
+
+        monkeypatch.setattr(_DESTINATION_REGISTRY, "get", lambda name: factory if name == "x" else None)
+
+        dest = _build_destination("x")
+
+        assert isinstance(dest, FakeDestination)
+        assert dest.name == "from-registry"
+        assert calls == [{"http_client": None}]
+
 
 class FakeDestination(Destination):
     def __init__(self, name_val: str = "fake", should_fail: bool = False):


### PR DESCRIPTION
## Summary
- refactor `app/services/routing.py` to resolve destinations via `DestinationRegistry`
- remove hardcoded provider branching in destination resolution
- add explicit `bootstrap_builtin_destinations()` for built-in destination registration
- preserve existing skip/warn behavior when Discord/Slack webhook env vars are missing
- add routing tests for built-in bootstrap and registry-based destination resolution

## Validation
- `TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=1 GITHUB_WEBHOOK_SECRET=x GENERIC_WEBHOOK_TOKEN=x ./.venv/bin/python -m pytest -q tests/test_routing.py tests/test_destination_registry.py`
