### PR TITLE
PR 4: Plugin DX and destination ops hardening

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -59,6 +59,7 @@ class Settings(BaseSettings):
 
     # Multi-destination routing
     routes_yaml: str = ""  # Path to YAML routing config or inline YAML
+    destination_feature_flags: str = ""  # CSV: telegram=true,discord=false
 
     # Discord destination
     discord_webhook_url: str = ""

--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,7 @@ from app.infra.middleware import RequestContextMiddleware, RateLimitMiddleware, 
 from app.observability.observability import RequestContextFilter
 from app.models.models import GenericWebhookPayload
 from app.api.replay import router as replay_router
-from app.services.routing import load_routes, route_event
+from app.services.routing import destination_health_snapshot, load_routes, route_event
 from app.api.sandbox import router as sandbox_router
 from app.core.security import describe_admin_auth_mode, verify_generic_token, verify_github_signature
 from app.infra.storage import FallbackStorage, Redis, RedisError, Storage, create_storage_backend
@@ -105,6 +105,12 @@ CIRCUIT_BREAKER_STATE = _get_or_create_counter(
     "circuit_breaker_state_changes_total",
     "Circuit breaker state changes",
     ["from_state", "to_state"]
+)
+
+ROUTE_DESTINATION_DELIVERIES = _get_or_create_counter(
+    "route_destination_deliveries_total",
+    "Per-destination delivery outcomes",
+    ["destination", "status"],
 )
 
 
@@ -288,6 +294,7 @@ def create_app() -> FastAPI:
                         "state": telegram_circuit.state.value,
                     },
                     "storage": _storage_health(app),
+                    "destinations": destination_health_snapshot(),
                 },
             )
         except TelegramError as exc:
@@ -301,6 +308,7 @@ def create_app() -> FastAPI:
                         "state": telegram_circuit.state.value,
                     },
                     "storage": _storage_health(app),
+                    "destinations": destination_health_snapshot(),
                 },
             )
 
@@ -395,6 +403,12 @@ def create_app() -> FastAPI:
                 payload,
                 http_client=request.app.state.http,
             )
+            for result in results:
+                ROUTE_DESTINATION_DELIVERIES.labels(
+                    destination=result.get("destination", "unknown"),
+                    status=result.get("status", "unknown"),
+                ).inc()
+
             any_sent = any(r["status"] == "sent" for r in results)
             any_failed = any(r["status"] == "failed" for r in results)
 
@@ -528,6 +542,12 @@ def create_app() -> FastAPI:
                 payload_dict,
                 http_client=request.app.state.http,
             )
+            for result in results:
+                ROUTE_DESTINATION_DELIVERIES.labels(
+                    destination=result.get("destination", "unknown"),
+                    status=result.get("status", "unknown"),
+                ).inc()
+
             any_sent = any(r["status"] == "sent" for r in results)
             any_failed = any(r["status"] == "failed" for r in results)
 

--- a/app/services/routing.py
+++ b/app/services/routing.py
@@ -41,6 +41,29 @@ from destinations.telegram import TelegramDestination
 logger = logging.getLogger(__name__)
 
 
+def _destination_flags() -> dict[str, bool]:
+    """Parse DESTINATION_FEATURE_FLAGS-like CSV from settings.
+
+    Format: "telegram=true,discord=false".
+    Unknown values default to enabled.
+    """
+    raw = getattr(settings, "destination_feature_flags", "")
+    flags: dict[str, bool] = {}
+    for item in raw.split(","):
+        item = item.strip()
+        if not item or "=" not in item:
+            continue
+        name, value = item.split("=", 1)
+        normalized = value.strip().lower()
+        enabled = normalized in {"1", "true", "yes", "on"}
+        flags[name.strip().lower()] = enabled
+    return flags
+
+
+def _is_destination_enabled(name: str) -> bool:
+    return _destination_flags().get(name.strip().lower(), True)
+
+
 @dataclass
 class RouteFilter:
     """Criteria that must all match for a route to fire."""
@@ -123,8 +146,38 @@ def bootstrap_builtin_destinations(registry: DestinationRegistry | None = None) 
 _DESTINATION_REGISTRY = bootstrap_builtin_destinations()
 
 
+def register_destination(name: str, factory: Any) -> None:
+    """Register a custom/plugin destination factory in the global registry."""
+    _DESTINATION_REGISTRY.register(name, factory)
+
+
+def destination_health_snapshot() -> dict[str, Any]:
+    """Routing destination snapshot for deep health checks."""
+    registered = _DESTINATION_REGISTRY.list_registered()
+    active: list[str] = []
+
+    for name in registered:
+        if not _is_destination_enabled(name):
+            continue
+        if name == "discord" and not settings.discord_webhook_url:
+            continue
+        if name == "slack" and not settings.slack_webhook_url:
+            continue
+        active.append(name)
+
+    return {
+        "registered": registered,
+        "active": active,
+        "fallback_safe": True,
+    }
+
+
 def _build_destination(name: str, http_client: httpx.AsyncClient | None = None) -> Destination | None:
     """Instantiate a destination by name via registry lookup."""
+    if not _is_destination_enabled(name):
+        logger.info("Destination %r disabled by feature flag", name)
+        return None
+
     factory = _DESTINATION_REGISTRY.get(name)
     if factory is None:
         logger.warning("Unknown destination %r in route config", name)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,73 @@
+# Destination Plugins
+
+This project supports destination plugins through the routing destination registry.
+
+## Destination contract
+
+A destination must implement `destinations.base.Destination`:
+
+- `name` property
+- `async send(message: str, *, event_type: str, payload: dict) -> None`
+- raise `DestinationError` on delivery failure
+
+## Minimal plugin template
+
+```python
+from typing import Any
+
+import httpx
+
+from destinations.base import Destination, DestinationError
+
+
+class CustomWebhookDestination(Destination):
+    def __init__(self, webhook_url: str, http_client: httpx.AsyncClient | None = None) -> None:
+        self._webhook_url = webhook_url
+        self._http_client = http_client
+
+    @property
+    def name(self) -> str:
+        return "custom_webhook"
+
+    async def send(self, message: str, *, event_type: str, payload: dict[str, Any]) -> None:
+        body = {"text": message, "event_type": event_type, "payload": payload}
+        try:
+            if self._http_client is not None:
+                resp = await self._http_client.post(self._webhook_url, json=body)
+                resp.raise_for_status()
+                return
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(self._webhook_url, json=body)
+                resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise DestinationError("custom_webhook", str(exc)) from exc
+```
+
+## Registration snippet
+
+```python
+from app.services.routing import register_destination
+from plugins.custom_webhook import CustomWebhookDestination
+
+
+def register_plugins() -> None:
+    register_destination(
+        "custom_webhook",
+        lambda **kwargs: CustomWebhookDestination(
+            webhook_url="https://example.internal/hook",
+            http_client=kwargs.get("http_client"),
+        ),
+    )
+```
+
+Call your plugin registration during app startup before webhook traffic begins.
+
+## Feature flags
+
+Set `DESTINATION_FEATURE_FLAGS` to selectively enable destinations:
+
+```bash
+DESTINATION_FEATURE_FLAGS="telegram=true,discord=false,slack=true,custom_webhook=true"
+```
+
+Disabled destinations are treated as skipped (safe fallback behavior).

--- a/examples/custom_webhook_destination.py
+++ b/examples/custom_webhook_destination.py
@@ -1,0 +1,48 @@
+"""Example destination plugin: custom webhook destination."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.services.routing import register_destination
+from destinations.base import Destination, DestinationError
+
+
+class CustomWebhookDestination(Destination):
+    def __init__(self, webhook_url: str, http_client: httpx.AsyncClient | None = None) -> None:
+        self._webhook_url = webhook_url
+        self._http_client = http_client
+
+    @property
+    def name(self) -> str:
+        return "custom_webhook"
+
+    async def send(self, message: str, *, event_type: str, payload: dict[str, Any]) -> None:
+        body = {
+            "text": message,
+            "event_type": event_type,
+            "repository": payload.get("repository", {}),
+        }
+        try:
+            if self._http_client is not None:
+                response = await self._http_client.post(self._webhook_url, json=body)
+                response.raise_for_status()
+                return
+            async with httpx.AsyncClient(timeout=10) as client:
+                response = await client.post(self._webhook_url, json=body)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise DestinationError("custom_webhook", str(exc)) from exc
+
+
+def register_example_plugin(webhook_url: str) -> None:
+    """Register this example destination into the global routing registry."""
+    register_destination(
+        "custom_webhook",
+        lambda **kwargs: CustomWebhookDestination(
+            webhook_url=webhook_url,
+            http_client=kwargs.get("http_client"),
+        ),
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -65,6 +65,10 @@ def test_health_deep_success(monkeypatch) -> None:
     assert data["storage"]["configured_backend"] == "memory"
     assert data["storage"]["effective_backend"] == "memory"
     assert data["storage"]["fallback_active"] is False
+    assert "destinations" in data
+    assert "registered" in data["destinations"]
+    assert "active" in data["destinations"]
+    assert data["destinations"]["fallback_safe"] is True
 
 
 def test_health_deep_failure(monkeypatch) -> None:
@@ -86,6 +90,7 @@ def test_health_deep_failure(monkeypatch) -> None:
     assert data["status"] == "degraded"
     assert data["telegram"]["connected"] is False
     assert "storage" in data
+    assert "destinations" in data
 
 
 def test_github_ping(monkeypatch) -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -12,6 +12,7 @@ from app.services.routing import (
     _extract_branch,
     _build_destination,
     bootstrap_builtin_destinations,
+    destination_health_snapshot,
     load_routes,
     route_event,
 )
@@ -178,6 +179,22 @@ class TestDestinationBootstrap:
         assert isinstance(dest, FakeDestination)
         assert dest.name == "from-registry"
         assert calls == [{"http_client": None}]
+
+    def test_destination_feature_flag_disables_destination(self, monkeypatch):
+        monkeypatch.setattr("app.services.routing.settings.destination_feature_flags", "telegram=false")
+
+        assert _build_destination("telegram") is None
+
+    def test_destination_health_snapshot(self, monkeypatch):
+        monkeypatch.setattr("app.services.routing.settings.destination_feature_flags", "slack=false")
+        monkeypatch.setattr("app.services.routing.settings.discord_webhook_url", "")
+
+        snap = destination_health_snapshot()
+
+        assert "telegram" in snap["registered"]
+        assert "telegram" in snap["active"]
+        assert "slack" not in snap["active"]
+        assert snap["fallback_safe"] is True
 
 
 class FakeDestination(Destination):


### PR DESCRIPTION
## Summary
- add `docs/plugins.md` with destination contract, minimal plugin template, and registration snippet
- add `examples/custom_webhook_destination.py` example plugin
- add per-destination observability counter labels (`destination`, `status`) for routed deliveries
- add destination feature-flag controls via `DESTINATION_FEATURE_FLAGS`
- improve `/health/deep` destination visibility with:
  - `registered`
  - `active`
  - `fallback_safe`

## Validation
- `TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=1 GITHUB_WEBHOOK_SECRET=x GENERIC_WEBHOOK_TOKEN=x ./.venv/bin/python -m pytest -q tests/test_routing.py tests/test_main.py`
