### PR TITLE
fix(ci): restore GHCR publish after uv editable requirements export

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -72,7 +72,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy SARIF to GitHub Security
-        if: always()
+        if: always() && hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -9,7 +9,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
-COPY requirements.txt .
+# requirements.txt includes `-e .` (editable install), so project metadata and
+# package source must be present at install time.
+COPY requirements.txt pyproject.toml README.md ./
+COPY app ./app
+COPY destinations ./destinations
 RUN pip install --no-cache-dir --user -r requirements.txt
 
 # Runtime stage


### PR DESCRIPTION
## Summary
- fix GHCR Docker build break introduced after `requirements.txt` started including `-e .`
- update `deploy/Dockerfile` to copy project metadata and package source (`pyproject.toml`, `README.md`, `app/`, `destinations/`) before `pip install -r requirements.txt`
- harden SARIF upload step to run only when `trivy-results.sarif` exists

## Root cause
`requirements.txt` now contains editable install (`-e .`) from uv export, but Docker builder only copied `requirements.txt` before dependency install. Pip then failed with:

> file:///app ... neither 'setup.py' nor 'pyproject.toml' found

## Validation
- inspected failing run logs: `Publish GHCR Image` run `22191090753`
- ensured Dockerfile now includes required project files before dependency install
