### PR TITLE
fix(ci): align GHCR sha tag with Trivy image reference

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -49,7 +49,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=tag
-            type=sha,prefix=sha-
+            type=sha,prefix=sha-,format=long
 
       - name: Build and push multi-arch image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- fix GHCR publish Trivy scan image reference mismatch
- update metadata tag generation from short SHA to full SHA (`type=sha,prefix=sha-,format=long`)

## Root cause
`docker/metadata-action` produced a short SHA tag (e.g. `sha-1dc69c2`), but Trivy scanned full SHA tag (`sha-${{ github.sha }}`), causing:

- `MANIFEST_UNKNOWN`
- `No such image`

## Validation
- failure reproduced in run `22191264594`
- this change makes built tag and Trivy scan target consistent
