### PR TITLE
docs: clarify replay-all async behavior and operator workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 - Improved admin auth env conflict warnings with explicit fix paths.
+- Clarified `POST /deliveries/replay-all` contract as asynchronous acceptance (`status: accepted`, `queued`) with background processing.
 
 ### Docs
 - Added release checklist smoke verification expansion and operational guidance.
+- Added replay operations guide with replay-all semantics and verification workflow: `docs/ops/replay-operations.md`.

--- a/README.md
+++ b/README.md
@@ -204,9 +204,22 @@ make down         # stop services
 | `/metrics` | GET | None | Prometheus metrics export |
 | `/deliveries` | GET | Admin API key (`read+`) | List failed deliveries |
 | `/deliveries/{id}/replay` | POST | Admin API key (`replay+`) | Replay one failed delivery |
-| `/deliveries/replay-all` | POST | Admin API key (`replay+`) | Replay eligible failed deliveries |
+| `/deliveries/replay-all` | POST | Admin API key (`replay+`) | Queue replay for eligible failed deliveries (async) |
 | `/stream/logs` | WS | Admin API key (`read+`) | Stream operational events/log metadata |
 
+### Replay-all behavior (important)
+
+`POST /deliveries/replay-all` is asynchronous and returns acceptance, not completion:
+
+```json
+{
+  "status": "accepted",
+  "queued": 12
+}
+```
+
+Use delivery status queries, logs, and metrics to verify replay completion. Full operator guidance:
+[`docs/ops/replay-operations.md`](docs/ops/replay-operations.md).
 
 ---
 

--- a/docs/ops/replay-operations.md
+++ b/docs/ops/replay-operations.md
@@ -1,0 +1,54 @@
+# Replay Operations (Admin API)
+
+This document clarifies the current behavior contract for replay endpoints.
+
+## Endpoints
+
+- `POST /deliveries/{id}/replay` — replay a single failed delivery
+- `POST /deliveries/replay-all` — replay all currently failed deliveries (up to internal limits)
+
+Both endpoints require admin auth with `replay` scope or higher.
+
+## Behavior Contract: `POST /deliveries/replay-all`
+
+### Previous operator expectation (historical)
+Some operators treated replay-all as effectively synchronous (request returns near completion state).
+
+### Current contract (v1.3+)
+`POST /deliveries/replay-all` is **asynchronous**:
+
+- API returns immediately with:
+  - `status: "accepted"`
+  - `queued: <number_of_failed_deliveries_queued_now>`
+- Replay processing continues in background tasks.
+- Processing concurrency is intentionally bounded to avoid overload.
+
+Example response:
+
+```json
+{
+  "status": "accepted",
+  "queued": 12
+}
+```
+
+## How to verify replay progress/outcome
+
+Use these signals instead of assuming immediate completion:
+
+1. **Delivery status API**
+   - `GET /deliveries?status=failed`
+   - `GET /deliveries?status=delivered`
+   - `GET /deliveries?status=dead_letter`
+2. **Application logs**
+   - Replay attempts, state transitions, and failure reasons
+3. **Health and observability**
+   - `/health/deep` for runtime dependency state
+   - `/metrics` for delivery/retry/failure counters
+
+## Operational notes
+
+- A high `queued` value means work was accepted, not completed.
+- Re-triggering replay-all repeatedly during active processing may create noisy operations.
+- Use targeted single-delivery replay when triaging specific failures.
+- For production, prefer Redis-backed storage/rate-limit backends for durable replay metadata.


### PR DESCRIPTION
## Summary
- clarify `POST /deliveries/replay-all` as asynchronous acceptance (not completion)
- add dedicated replay operator guide: `docs/ops/replay-operations.md`
- update compact API docs wording and changelog release note

## Changes
- README API section now explicitly describes replay-all as queued async replay
- Added `Replay-all behavior (important)` section with concrete response example
- Added ops runbook for verifying replay outcomes via `/deliveries`, logs, `/health/deep`, and `/metrics`
- Added changelog entry for this behavioral contract clarification

## Why
Operators previously treated replay-all as near-synchronous. Current implementation is background-task based and bounded-concurrency; docs now match runtime behavior and provide a verification workflow.

Fixes #46
