### PR TITLE
ci(security): define Trivy GHCR gate policy and release gating

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -61,6 +61,17 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Determine Trivy gate mode
+        id: trivy_mode
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "mode=blocking-release" >> "$GITHUB_OUTPUT"
+            echo "exit_code=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=non-blocking-main" >> "$GITHUB_OUTPUT"
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@0.24.0
         with:
@@ -68,11 +79,22 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
-          exit-code: "0"
+          exit-code: ${{ steps.trivy_mode.outputs.exit_code }}
           ignore-unfixed: true
+          trivyignores: .trivyignore
+
+      - name: Trivy gate summary
+        if: always()
+        run: |
+          echo "## GHCR Trivy Gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Mode: `${{ steps.trivy_mode.outputs.mode }}`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Exit code policy: `${{ steps.trivy_mode.outputs.exit_code }}` (1=blocking, 0=non-blocking)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Scope: CRITICAL,HIGH (ignore unfixed=true)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Baseline/Suppressions: `.trivyignore` (tracked with owner + expiry)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Policy doc: `docs/ops/trivy-ghcr-policy.md`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Trivy SARIF to GitHub Security
         if: always() && hashFiles('trivy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# Trivy suppression baseline for GHCR image scanning
+#
+# Rules:
+# 1) Every ignored CVE MUST have:
+#    - owner
+#    - reason
+#    - tracking issue/PR
+#    - expiry date (UTC)
+# 2) Expired suppressions must be removed or renewed with updated justification.
+# 3) Keep this file short and review it during each release.
+#
+# Example (uncomment + update fields):
+# CVE-2026-12345 # owner=@dunrip reason=upstream-fix-pending issue=#123 expires=2026-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 - Improved admin auth env conflict warnings with explicit fix paths.
 - Clarified `POST /deliveries/replay-all` contract as asynchronous acceptance (`status: accepted`, `queued`) with background processing.
+- GHCR Trivy gate now distinguishes non-release (`main`) non-blocking scans vs release-tag blocking scans, with CI step summaries.
 
 ### Docs
 - Added release checklist smoke verification expansion and operational guidance.
 - Added replay operations guide with replay-all semantics and verification workflow: `docs/ops/replay-operations.md`.
+- Added Trivy GHCR gate policy and suppression process documentation: `docs/ops/trivy-ghcr-policy.md`.

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ image:
 - Use strong random secrets for all token/key fields
 - Prefer scoped admin keys over legacy single key
 - Keep CI security workflows enabled (dependency + secrets scanning)
+- Follow container vulnerability gate policy for GHCR publishes: [`docs/ops/trivy-ghcr-policy.md`](docs/ops/trivy-ghcr-policy.md)
 - Follow the CI failure triage checklist: [`docs/ops/ci-failure-triage.md`](docs/ops/ci-failure-triage.md)
 - Use benchmark baseline guardrails: [`docs/monitoring/reliability-benchmark.md`](docs/monitoring/reliability-benchmark.md)
 

--- a/docs/ops/trivy-ghcr-policy.md
+++ b/docs/ops/trivy-ghcr-policy.md
@@ -1,0 +1,59 @@
+# Trivy GHCR Gate Policy
+
+This policy defines how container vulnerability findings are handled in `Publish GHCR Image`.
+
+## Scope
+
+- Scanner: Trivy (`aquasecurity/trivy-action`)
+- Artifact: `ghcr.io/dunrip/dunrip-webhook-bridge`
+- Findings scope: `CRITICAL,HIGH`
+- `ignore-unfixed: true` (focus on actionable fixes)
+
+## Gate Modes
+
+### 1) Non-release mode (push to `main`)
+- **Mode:** `non-blocking-main`
+- **Exit code:** `0`
+- **Behavior:** Workflow stays green while still publishing SARIF + summary.
+- **Goal:** Keep delivery flow stable while surfacing risk continuously.
+
+### 2) Release mode (tag `v*`)
+- **Mode:** `blocking-release`
+- **Exit code:** `1`
+- **Behavior:** Workflow fails if CRITICAL/HIGH actionable findings exist.
+- **Goal:** Prevent shipping a tagged release with unaccepted high-risk findings.
+
+## Baseline & Suppression Strategy
+
+Known accepted findings are tracked in `.trivyignore`.
+
+Each suppression entry must include:
+- Owner
+- Reason
+- Tracking issue/PR
+- Expiry date (UTC)
+
+Expired entries must be removed or explicitly renewed with updated justification.
+
+## Remediation SLA
+
+Use `SECURITY.md` severity targets as default remediation timeline:
+- Critical: acknowledge within 24h, mitigation plan within 72h, patch target within 7 days
+- High: acknowledge within 2 business days, fix plan within 5 business days, patch target within 14 days
+
+## CI Summary Requirements
+
+`Publish GHCR Image` writes a step summary with:
+- Active gate mode
+- Blocking/non-blocking exit behavior
+- Scan scope and ignore-unfixed policy
+- Baseline source (`.trivyignore`)
+- Link to this policy
+
+## Operational Workflow
+
+1. Review SARIF findings in GitHub Security tab.
+2. If fixable quickly, patch dependencies/base image and rerun.
+3. If not immediately fixable, create/attach tracking issue.
+4. Only add suppression with owner + expiry + rationale.
+5. Before tag/release, confirm no unaccepted CRITICAL/HIGH findings.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -27,6 +27,7 @@ Examples:
 - [ ] `Security - Dependency Scan` workflow is green for commit/tag to release
 - [ ] `Security - Secrets Scan` workflow is green for commit/tag to release
 - [ ] No unresolved Critical/High vulnerabilities without explicit risk acceptance
+- [ ] Trivy gate mode is `blocking-release` for tag builds and findings are reviewed against `docs/ops/trivy-ghcr-policy.md`
 - [ ] Security remediation SLA impact reviewed against `SECURITY.md`
 
 ## Release prep


### PR DESCRIPTION
## Summary
- define and document Trivy GHCR gate policy with release vs non-release behavior
- add suppression baseline process (`.trivyignore`) with owner + expiry requirements
- add CI step summary to clearly show blocking/non-blocking gate mode

## Changes
- `Publish GHCR Image` now sets gate mode by ref:
  - `main` push: non-blocking (`exit-code=0`)
  - `v*` tag: blocking (`exit-code=1`)
- Trivy now reads `.trivyignore` for managed, time-boxed suppressions
- Added workflow summary output with gate mode, scope, and policy link
- Upgraded SARIF upload action to `github/codeql-action/upload-sarif@v4`
- Added policy doc: `docs/ops/trivy-ghcr-policy.md`
- Updated release checklist + README security notes + changelog

## Why
This makes policy explicit, reduces noisy non-release failures, and preserves strict release gating with a repeatable triage + exception process.

Fixes #47
