### PR TITLE
fix(ci): restore Codecov uploads with token auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
-          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
           flags: unit
           name: python-3.11
 


### PR DESCRIPTION
## Summary
- fix Codecov upload auth by passing `CODECOV_TOKEN` from repo secrets
- make Codecov upload failures fail CI (`fail_ci_if_error: true`) so misconfigurations are visible

## Why
Codecov badge showed `unknown` because CI upload was tokenless and silently ignored (`fail_ci_if_error: false`).

## Action required
Add repository secret:
- `CODECOV_TOKEN` (from Codecov for `Dunrip/dunrip-webhook-bridge`)

After the secret is added, re-run CI on `main` and the Codecov badge should update from `unknown`.
