### PR TITLE
fix(security): remediate open Trivy code-scanning alerts

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -81,6 +81,7 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: ${{ steps.trivy_mode.outputs.exit_code }}
           ignore-unfixed: true
+          scanners: vuln
           trivyignores: .trivyignore
 
       - name: Trivy gate summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Improved admin auth env conflict warnings with explicit fix paths.
 - Clarified `POST /deliveries/replay-all` contract as asynchronous acceptance (`status: accepted`, `queued`) with background processing.
 - GHCR Trivy gate now distinguishes non-release (`main`) non-blocking scans vs release-tag blocking scans, with CI step summaries.
+- GHCR image build now refreshes pip/setuptools/wheel toolchain in builder/runtime stages to reduce known Trivy CVEs.
+- Trivy GHCR workflow now uses vulnerability scanner mode (`scanners: vuln`) to avoid secret-pattern false positives from package metadata.
 
 ### Docs
 - Added release checklist smoke verification expansion and operational guidance.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,12 +1,13 @@
 # Build stage
-FROM python:3.11-slim as builder
+FROM python:3.11-slim AS builder
 
 WORKDIR /app
 
-# Install build dependencies
+# Install build dependencies + refresh packaging toolchain to patched versions
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && python -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
 # Install Python dependencies
 # requirements.txt includes `-e .` (editable install), so project metadata and
@@ -20,6 +21,9 @@ RUN pip install --no-cache-dir --user -r requirements.txt
 FROM python:3.11-slim
 
 WORKDIR /app
+
+# Refresh packaging toolchain in final image to avoid known CVEs reported by Trivy
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
 # Create non-root user for security
 RUN groupadd -r appuser && useradd -r -g appuser appuser

--- a/docs/ops/trivy-ghcr-policy.md
+++ b/docs/ops/trivy-ghcr-policy.md
@@ -7,7 +7,9 @@ This policy defines how container vulnerability findings are handled in `Publish
 - Scanner: Trivy (`aquasecurity/trivy-action`)
 - Artifact: `ghcr.io/dunrip/dunrip-webhook-bridge`
 - Findings scope: `CRITICAL,HIGH`
+- Scanners: `vuln` (OS + library vulnerabilities)
 - `ignore-unfixed: true` (focus on actionable fixes)
+- Secret scanning remains covered by `Security - Secrets Scan` (gitleaks)
 
 ## Gate Modes
 


### PR DESCRIPTION
## Summary
- remediate open Trivy code-scanning findings by refreshing pip/setuptools/wheel in Docker image stages
- reduce noisy false-positive code scanning alert (`jwt-token` from package metadata example text) by scanning vulnerabilities only in GHCR Trivy step
- align security policy docs/changelog with actual scanner scope

## Root cause
Open code scanning alerts were coming from Trivy SARIF uploads on `main`:
- High CVEs in packaging toolchain versions inherited by the image (`pip`, `wheel`, vendored `jaraco.context`)
- One medium secret-pattern alert (`jwt-token`) from package metadata example text, not app secrets

## Changes
- `deploy/Dockerfile`
  - Upgrade `pip setuptools wheel` in both builder and runtime stages
  - Also fixes Dockerfile style warning (`FROM ... AS builder`)
- `.github/workflows/ghcr-publish.yml`
  - Add `scanners: vuln` to Trivy step (keep vuln signal, avoid secret-pattern noise)
- `docs/ops/trivy-ghcr-policy.md`
  - Document scanner scope and note that secret scanning remains handled by gitleaks workflow
- `CHANGELOG.md`
  - Record remediation + scanner scope change

## Expected result
After merge and a new GHCR publish scan on `main`, existing code scanning alerts should close if no longer present in uploaded SARIF.
